### PR TITLE
feat(spec): add /v2/gliders

### DIFF
--- a/docs/changelog/0.2.0.md
+++ b/docs/changelog/0.2.0.md
@@ -1,3 +1,8 @@
 # 0.2.0
 
 _Not Released Yet_
+
+### Improvements
+
+- Endpoints:
+    - Added support for `/v2/gliders`. [[GH-80](https://github.com/GW2ToolBelt/api-generator/issues/80)]

--- a/src/main/kotlin/com/gw2tb/apigen/internal/spec/GW2v2.kt
+++ b/src/main/kotlin/com/gw2tb/apigen/internal/spec/GW2v2.kt
@@ -526,6 +526,24 @@ internal val GW2v2 = GW2APIVersion {
             "Icon"(STRING, "the URL to the image")
         })
     }
+    "/Gliders" {
+        summary = "Returns information about gliders."
+        cache = 1.hours
+        isLocalized = true
+
+        supportedQueries(BY_ID, BY_IDS, BY_PAGE)
+        schema(record(name = "Glider", description = "Information about a glider.") {
+            "Id"(INTEGER, "the glider's ID")
+            "Name"(STRING, "the glider's name")
+            "Description"(STRING, "the glider's description")
+            "Icon"(STRING, "the URL for the glider's icon")
+            "Order"(INTEGER, "a (non-unique) number that can be used as basis to sort the list of gliders")
+            SerialName("default_dyes").."DefaultDyes"(
+                description = "the IDs of the dyes that are applied to the glider by default",
+                type = array(INTEGER)
+            )
+        })
+    }
     "/Items" {
         summary = "Returns information about items in the game."
         cache = 1.hours


### PR DESCRIPTION
"Soft-blocked" until the fix for https://github.com/arenanet/api-cdi/issues/667 is deployed to live. If the endpoint turns out to be desperately needed, I could either unset `isLocalized` temporarily or just merge as-is and ignore that the actual returned data is not localized. For now, though, I haven't decided and will not merge it.

Closes #80.