### PR TITLE
Mark account.build_storage_slots as optional

### DIFF
--- a/src/main/kotlin/com/gw2tb/apigen/internal/spec/GW2v2.kt
+++ b/src/main/kotlin/com/gw2tb/apigen/internal/spec/GW2v2.kt
@@ -372,7 +372,7 @@ internal val GW2v2 = GW2APISpecV2 {
                 STRING,
                 "the ISO-8601 standard timestamp of when the account information last changed (as perceived by the API)"
             )
-            since(V2_SCHEMA_2019_12_19T00_00_00_000Z)..SerialName("build_storage_slots").."BuildStorageSlots"(
+            since(V2_SCHEMA_2019_12_19T00_00_00_000Z)..optional(BUILDS)..SerialName("build_storage_slots").."BuildStorageSlots"(
                 INTEGER,
                 "the number of the account's account-wide build storage slots unlocked"
             )


### PR DESCRIPTION
`account.build_storage_slots` is only returned if the `builds` scope has been granted. This can cause a `MissingFieldException` in GW2APIClient when trying to use the `v2/Account` endpoint with an API key that doesn't have the `builds` scope.